### PR TITLE
WIP Charge object logic

### DIFF
--- a/commerce_license_billing.info
+++ b/commerce_license_billing.info
@@ -15,6 +15,7 @@ dependencies[] = views_megarow
 files[] = commerce_license_billing.info.inc
 files[] = plugins/billing_cycle_engine/base.inc
 files[] = includes/commerce_license_billing.interface.inc
+files[] = includes/commerce_license_billing.charge.inc
 files[] = includes/commerce_license_billing.cycle_type_ui.inc
 files[] = includes/commerce_license_billing.cycle.inc
 

--- a/commerce_license_billing.module
+++ b/commerce_license_billing.module
@@ -1037,16 +1037,13 @@ function commerce_license_billing_collect_charges(CommerceLicenseInterface $lice
     if (!$scheduled_for_cancellation) {
       $billing_cycle_type = entity_load_single('cl_billing_cycle_type', $billing_cycle->type);
       $next_billing_cycle = $billing_cycle_type->getNextBillingCycle($billing_cycle, FALSE);
-      $def = array(
-        'license_revision_id' => $license->revision_id,
+      $plan_record = array(
+        'revision_id' => $license->revision_id,
         'quantity' => 1,
-        'commerce_product' => $product_wrapper->value(),
-        'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-        'cl_billing_start' => $next_billing_cycle->start,
-        'cl_billing_end' => $next_billing_cycle->end,
-        'match' => array('commerce_product'),
+        'start' => $next_billing_cycle->start,
+        'end' => $next_billing_cycle->end,
       );
-      $plan_charges[] = new CommerceLicenseBillingCharge($def);
+      $plan_charges[] = new CommerceLicenseBillingCharge($plan_record, $product_wrapper, array('commerce_product'));
     }
   }
   elseif ($product_wrapper->cl_billing_type->value() == 'postpaid') {
@@ -1609,17 +1606,10 @@ function commerce_license_billing_plan_history_charges(CommerceLicenseInterface 
     $product = $products[$history_record['product_id']];
     $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
 
-    $def = array(
-      'license_revision_id' => $history_record['revision_id'],
-      'quantity' => 1,
-      'commerce_product' => $product,
-      'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-      'cl_billing_start' => $history_record['start'],
-      'cl_billing_end' => $history_record['end'],
-      'match' => array('commerce_product', 'cl_billing_start'),
-    );
+    $history_record['quantity'] = 1;
+    $match = array('commerce_product', 'cl_billing_start');
 
-    $charges[] = new CommerceLicenseBillingCharge($def);
+    $charges[] = new CommerceLicenseBillingCharge($history_record, $product_wrapper, $match);
   }
 
   return $charges;

--- a/commerce_license_billing.module
+++ b/commerce_license_billing.module
@@ -1645,23 +1645,33 @@ function commerce_license_billing_plan_history_charges(CommerceLicenseInterface 
 function commerce_license_billing_usage_history_list(CommerceLicenseBillingUsageInterface $license, $billing_cycle) {
   $history = &drupal_static(__FUNCTION__, array());
   if (!isset($history[$billing_cycle->billing_cycle_id][$license->license_id])) {
-    $data = array(
-      ':license_id' => $license->license_id,
-      ':start' => $billing_cycle->start,
-      ':end' => $billing_cycle->end,
-    );
     // Fetch usage records that overlap this billing cycle. See
     // commerce_license_billing_plan_history_list for details.
-    $result = db_query("SELECT * FROM {cl_billing_usage}
-                          WHERE license_id = :license_id
-                              AND (
-                                (start < :end) AND (
-                                  (end > :start) OR
-                                  (end = 0)
-                                )
-                              )
-                          ORDER BY start ASC", $data);
-    $usage_history = $result->fetchAll(PDO::FETCH_ASSOC);
+    $query = db_select("cl_billing_usage", "clbu");
+    $query->fields("clbu");
+    $time_condition = db_and();
+    // First condition is "start before cycle end"
+    $time_condition->condition("clbu.start", $billing_cycle->end, "<");
+    // Second condition is composite OR:
+    $second_cond = db_or();
+    // Either "end after cycle start" or "no end a.k.a. 0"
+    // @TODO: Fix cycle dates to not use 0 for "never"
+    $second_cond->condition("clbu.end", $billing_cycle->start, ">");
+    $second_cond->condition("clbu.end", 0, "=");
+    // Add the combined OR to the AND as a group
+    $time_condition->condition($second_cond);
+
+    // Add this to the main query. These are AND together by default.
+    $query->condition("clbu.license_id", $license->license_id);
+    $query->condition($time_condition);
+    $query->orderBy("clbu.start", "ASC");
+
+    // If anyone feels really fancy, they can alter the query.
+    // This is recommended for usage groups which want to implement custom or
+    // multi-record storage outside of the base cl_billing_usage table.
+    $query->addTag("cl_billing_usage_history_list");
+
+    $usage_history = $query->execute()->fetchAll(PDO::FETCH_ASSOC);
 
     $group_history = array();
     foreach ($usage_history as $usage_record) {

--- a/commerce_license_billing.module
+++ b/commerce_license_billing.module
@@ -155,6 +155,28 @@ function commerce_license_billing_entity_info_alter(&$entity_info) {
 }
 
 /**
+ * Implements hook_entity_property_info_alter().
+ */
+function commerce_license_billing_entity_property_info_alter(&$info) {
+  $info['commerce_line_item']['bundles']['recurring']['properties']['cl_billing_charge'] = array(
+    'label' => t('Line item charge'),
+    'type' => 'struct',
+    'getter callback' => 'commerce_license_billing_get_charge',
+  );
+}
+
+/**
+ * Getter function for returning the charge which generated a recurring line item.
+ */
+function commerce_license_billing_get_charge($line_item, array $options, $name, $type, $info) {
+  if (!empty($line_item->data['charge'])) {
+    return $line_item->data['charge'];
+  }
+
+  return NULL;
+}
+
+/**
  * Implements hook_commerce_line_item_type_info().
  */
 function commerce_license_billing_commerce_line_item_type_info() {
@@ -811,12 +833,12 @@ function commerce_license_billing_order_refresh($order, $set_refresh_timer = FAL
       $existing_line_item = NULL;
       // Try to find an existing line item that can be updated.
       foreach ($old_line_items[$license_id] as $line_item_wrapper) {
-        $match = TRUE;
-        foreach ($charge['match'] as $key) {
-          if ($line_item_wrapper->{$key}->value() != $charge[$key]) {
-            $match = FALSE;
-            break;
-          }
+        if ($charge instanceof CommerceLicenseBillingChargeInterface) {
+          $match = $charge->match($line_item_wrapper);
+        }
+        else {
+          // Support backwards compatibility with non-object charges.
+          $match = _commerce_license_billing_charge_match($charge, $line_item_wrapper);
         }
 
         if ($match) {
@@ -935,30 +957,41 @@ function commerce_license_billing_line_item_new(CommerceLicenseInterface $licens
  */
 function commerce_license_billing_populate_line_item($line_item, $charge) {
   $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
-  $line_item_wrapper->line_item_label = $charge['commerce_product']->sku;
-  $line_item_wrapper->commerce_product = $charge['commerce_product'];
-  $line_item_wrapper->quantity = $charge['quantity'];
-  $line_item_wrapper->commerce_unit_price = $charge['commerce_unit_price'];
-  // We strip out price and product details, and retain the rest of the info on
-  // the price component.
-  $base_component = $line_item_wrapper->commerce_unit_price->value();
-  unset($charge['commerce_product'], $charge['commerce_unit_price']);
-  $base_component['data'] = array(
-    'charge' => $charge,
-  );
+  if ($charge instanceof CommerceLicenseBillingChargeInterface) {
+    $charge->populate($line_item_wrapper);
+  }
+  else {
+    $line_item_wrapper->line_item_label = $charge['commerce_product']->sku;
+    $line_item_wrapper->commerce_product = $charge['commerce_product'];
+    $line_item_wrapper->quantity = $charge['quantity'];
+    $line_item_wrapper->commerce_unit_price = $charge['commerce_unit_price'];
+    // We strip out price and product details, and retain the rest of the charge
+    // on the price component.
+    $base_component = $line_item_wrapper->commerce_unit_price->value();
+    unset($charge['commerce_product'], $charge['commerce_unit_price']);
+    // Charges are now stored on the line item's data array directly rather
+    // than on a price component which might be accidentally changed by pricing
+    // rules. This is left for BC reasons but users relying on the charge data
+    // should move to the new property_info implementation.
+    $base_component['data'] = array(
+      'charge' => $charge,
+    );
+    $line_item->data['charge'] = $charge;
 
-
-  $line_item_wrapper->commerce_unit_price->data = commerce_price_component_add(
-    $line_item_wrapper->commerce_unit_price->value(),
-    'base_price',
-    $base_component,
-    TRUE
-  );
-  $line_item->cl_billing_start[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $charge['cl_billing_start']);
-  $line_item->cl_billing_end[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $charge['cl_billing_end']);
-  // Store the revision ID of the license used to generate the charge, if any.
-  if (!empty($charge['license_revision_id'])) {
-    $line_item->data['license_revision_id'] = $charge['license_revision_id'];
+    $line_item_wrapper->commerce_unit_price->data = commerce_price_component_add(
+      $line_item_wrapper->commerce_unit_price->value(),
+      'base_price',
+      $base_component,
+      TRUE
+    );
+    $line_item->cl_billing_start[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $charge['cl_billing_start']);
+    $line_item->cl_billing_end[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $charge['cl_billing_end']);
+    // Store the revision ID of the license used to generate the charge, if any.
+    // With the change to store the generating charge directly on the line item
+    // this is no longer necessary, but is left for BC reasons.
+    if (!empty($charge['license_revision_id'])) {
+      $line_item->data['license_revision_id'] = $charge['license_revision_id'];
+    }
   }
 
   // Trigger price calculation to get any needed discounts or price changes.
@@ -984,7 +1017,7 @@ function commerce_license_billing_populate_line_item($line_item, $charge) {
  *     when looking for an existing line item for the charge.
  */
 function commerce_license_billing_collect_charges(CommerceLicenseInterface $license, $billing_cycle) {
-  $charges = array();
+  $plan_charges = array();
   // Charge the plan.
   // In case of prepaid, the plan charge is for the entire next billing cycle.
   // In case of postpaid, all plan changes in the current month are charged.
@@ -1004,7 +1037,7 @@ function commerce_license_billing_collect_charges(CommerceLicenseInterface $lice
     if (!$scheduled_for_cancellation) {
       $billing_cycle_type = entity_load_single('cl_billing_cycle_type', $billing_cycle->type);
       $next_billing_cycle = $billing_cycle_type->getNextBillingCycle($billing_cycle, FALSE);
-      $charges[] = array(
+      $def = array(
         'license_revision_id' => $license->revision_id,
         'quantity' => 1,
         'commerce_product' => $product_wrapper->value(),
@@ -1013,60 +1046,46 @@ function commerce_license_billing_collect_charges(CommerceLicenseInterface $lice
         'cl_billing_end' => $next_billing_cycle->end,
         'match' => array('commerce_product'),
       );
+      $plan_charges[] = new CommerceLicenseBillingCharge($def);
     }
   }
   elseif ($product_wrapper->cl_billing_type->value() == 'postpaid') {
-    $plan_history = commerce_license_billing_plan_history_list($license, $billing_cycle);
-    // Gather all products.
-    $product_ids = array();
-    foreach ($plan_history as $history_record) {
-      $product_ids[] = $history_record['product_id'];
-    }
-    $products = commerce_product_load_multiple($product_ids);
-
-    foreach ($plan_history as $history_record) {
-      $product = $products[$history_record['product_id']];
-      $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
-
-      $charges[] = array(
-        'license_revision_id' => $history_record['revision_id'],
-        'quantity' => 1,
-        'commerce_product' => $product,
-        'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-        'cl_billing_start' => $history_record['start'],
-        'cl_billing_end' => $history_record['end'],
-        'match' => array('commerce_product', 'cl_billing_start'),
-      );
-    }
+    $plan_charges = commerce_license_billing_plan_history_charges($license, $billing_cycle);
   }
 
   // Charge for usage, if the license type supports it.
+  $usage_charges = array();
   if ($license instanceof CommerceLicenseBillingUsageInterface) {
     $usage_groups = $license->usageGroups();
     foreach ($usage_groups as $group_name => $group_info) {
       $usage_group = commerce_license_billing_usage_group($license, $group_name);
       $chargeable_usage = $usage_group->chargeableUsage($billing_cycle);
-      foreach ($chargeable_usage as $usage_record) {
-        $product = commerce_product_load_by_sku($group_info['product']);
-        $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
-
-        $charges[] = array(
-          // Not all usage records supply the revision ID of the license, as
-          //   is it not always relevant.
-          'license_revision_id' => (isset($usage_record['revision_id']) ? $usage_record['revision_id'] : NULL),
-          'commerce_product' => $product,
-          'quantity' => $usage_record['quantity'],
-          'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-          'cl_billing_start' => $usage_record['start'],
-          'cl_billing_end' => $usage_record['end'],
-          'match' => array('commerce_product', 'cl_billing_start'),
-          'usage_group' => $usage_record['usage_group'],
-        );
+      foreach ($chargeable_usage as $charge) {
+        $usage_charges[] = $charge;
       }
     }
   }
 
+  $charges = array_merge($plan_charges, $usage_charges);
+
+  drupal_alter('commerce_license_billing_charges', $charges, $license, $billing_cycle);
+
   return $charges;
+}
+
+/**
+ * Used for backwards compatibility. Match a charge record against
+ * a line item wrapper.
+ */
+function _commerce_license_billing_charge_match($charge, $line_item_wrapper) {
+  $match = TRUE;
+  foreach ($charge['match'] as $key) {
+    if ($line_item_wrapper->{$key}->value() != $charge[$key]) {
+      $match = FALSE;
+      break;
+    }
+  }
+  return $match;
 }
 
 /**
@@ -1238,7 +1257,7 @@ function commerce_license_billing_calculate_sell_price($order_id, $product, $qua
  *   A billing cycle entity, or FALSE if none found.
  *
  * This function does a complex set of joins to get the latest billing cycle for
- * a given license. This is done (rather than using EntityFieldQuery) * because
+ * a given license. This is done (rather than using EntityFieldQuery) because
  * EFQ cannot chain entity references, and it ended up being more efficient to
  * do several direct joins and get back the billing cycle ID.
  *
@@ -1562,6 +1581,48 @@ function commerce_license_billing_plan_history_list(CommerceLicenseInterface $li
   }
 
   return $history[$billing_cycle->billing_cycle_id][$license->license_id];
+}
+
+/**
+ * Turns the license plan history for a given license and billing cycle into
+ * charge objects.
+ *
+ * @param $license
+ *   The license entity
+ * @param $billing_cycle
+ *   This billing cycle entity.
+ *
+ * @return CommerceLicenseBillingChargeInterface[]
+ */
+function commerce_license_billing_plan_history_charges(CommerceLicenseInterface $license, $billing_cycle) {
+  $plan_history = commerce_license_billing_plan_history_list($license, $billing_cycle);
+  $charges = array();
+
+  // Gather all products to do a bit of performance-improving preloading.
+  $product_ids = array();
+  foreach ($plan_history as $history_record) {
+    $product_ids[] = $history_record['product_id'];
+  }
+  $products = commerce_product_load_multiple($product_ids);
+
+  foreach ($plan_history as $history_record) {
+    $product = $products[$history_record['product_id']];
+    $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+
+    $def = array(
+      'license_revision_id' => $history_record['revision_id'],
+      'quantity' => 1,
+      'commerce_product' => $product,
+      'commerce_unit_price' => $product_wrapper->commerce_price->value(),
+      'cl_billing_start' => $history_record['start'],
+      'cl_billing_end' => $history_record['end'],
+      'match' => array('commerce_product', 'cl_billing_start'),
+    );
+
+    $charges[] = new CommerceLicenseBillingCharge($def);
+  }
+
+  return $charges;
 }
 
 /**

--- a/includes/commerce_license_billing.charge.inc
+++ b/includes/commerce_license_billing.charge.inc
@@ -1,0 +1,118 @@
+<?php
+
+interface CommerceLicenseBillingChargeInterface extends ArrayAccess {
+  public function match($line_item_wrapper);
+
+  public function populate($line_item_wrapper);
+}
+
+class CommerceLicenseBillingCharge implements CommerceLicenseBillingChargeInterface {
+
+  const SCHEMA = [
+    'usage_group',
+    'quantity',
+    'commerce_product',
+    'commerce_unit_price',
+    'license_revision_id',
+    'cl_billing_start',
+    'cl_billing_end',
+    'match',
+  ];
+
+  protected $container = array();
+
+  public function __construct(array $def) {
+    foreach ($def as $k => $v) {
+      if (!in_array($k, static::SCHEMA)) {
+        throw new DomainException("This charge type does not support the $k data element.");
+      }
+      $this->container[$k] = $v;
+    }
+
+    // Fill in the blanks.
+    foreach (static::SCHEMA as $k) {
+      if (!isset($this->container[$k])) {
+        $this->container[$k] = NULL;
+      }
+    }
+  }
+
+  public function match($line_item_wrapper) {
+    if (empty($this->container['match'])) {
+      throw new LogicException("Unable to match line items as no matching elements are defined for this charge.");
+    }
+    $match = TRUE;
+    foreach ($this->container['match'] as $key) {
+      if (!in_array($key, static::SCHEMA)) {
+        throw new DomainException("Trying to match data value not in the schema for this charge type.");
+      }
+
+      if ($line_item_wrapper->{$key}->value() != $this->container[$key]) {
+        $match = FALSE;
+        break;
+      }
+    }
+
+    return $match;
+  }
+
+  public function populate($line_item_wrapper) {
+    $line_item = $line_item_wrapper->value();
+    $line_item_wrapper->line_item_label = $this->container['commerce_product']->sku;
+    $line_item_wrapper->commerce_product = $this->container['commerce_product'];
+    $line_item_wrapper->quantity = $this->container['quantity'];
+    $line_item_wrapper->commerce_unit_price = $this->container['commerce_unit_price'];
+    // We strip out price and product details, and retain the rest of the charge
+    // on the price component.
+    $base_component = $line_item_wrapper->commerce_unit_price->value();
+    unset($this->container['commerce_product'], $this->container['commerce_unit_price']);
+    // Charges are now stored on the line item's data array directly rather
+    // than on a price component which might be accidentally changed by pricing
+    // rules. This is left for BC reasons but users relying on the charge data
+    // should move to the new property_info implementation.
+    $base_component['data'] = array(
+      'charge' => $this,
+    );
+    $line_item->data['charge'] = $this;
+
+    $line_item_wrapper->commerce_unit_price->data = commerce_price_component_add(
+      $line_item_wrapper->commerce_unit_price->value(),
+      'base_price',
+      $base_component,
+      TRUE
+    );
+    $line_item->cl_billing_start[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $this->container['cl_billing_start']);
+    $line_item->cl_billing_end[LANGUAGE_NONE][0]['value'] = date("Y-m-d H:i:s", $this->container['cl_billing_end']);
+    // Store the revision ID of the license used to generate the charge, if any.
+    // With the change to store the generating charge directly on the line item
+    // this is no longer necessary, but is left for BC reasons.
+    if (!empty($this->container['license_revision_id'])) {
+      $line_item->data['license_revision_id'] = $this->container['license_revision_id'];
+    }
+  }
+
+  public function offsetSet($offset, $value) {
+    if (is_null($offset)) {
+      throw new DomainException("This charge type does not support unmapped data elements.");
+    }
+    elseif (!in_array($offset, static::SCHEMA)) {
+      throw new DomainException("This charge type does not support the $offset data element.");
+    }
+    else {
+      $this->container[$offset] = $value;
+    }
+  }
+
+  public function offsetExists($offset) {
+    return isset($this->container[$offset]);
+  }
+
+  public function offsetUnset($offset) {
+    unset($this->container[$offset]);
+  }
+
+  public function offsetGet($offset) {
+    return isset($this->container[$offset]) ? $this->container[$offset] : null;
+  }
+
+}

--- a/includes/commerce_license_billing.charge.inc
+++ b/includes/commerce_license_billing.charge.inc
@@ -8,7 +8,7 @@ interface CommerceLicenseBillingChargeInterface extends ArrayAccess {
 
 class CommerceLicenseBillingCharge implements CommerceLicenseBillingChargeInterface {
 
-  const SCHEMA = [
+  protected static $schema = array(
     'usage_group',
     'quantity',
     'commerce_product',
@@ -17,20 +17,32 @@ class CommerceLicenseBillingCharge implements CommerceLicenseBillingChargeInterf
     'cl_billing_start',
     'cl_billing_end',
     'match',
-  ];
+  );
 
   protected $container = array();
 
-  public function __construct(array $def) {
-    foreach ($def as $k => $v) {
-      if (!in_array($k, static::SCHEMA)) {
-        throw new DomainException("This charge type does not support the $k data element.");
-      }
-      $this->container[$k] = $v;
+  public function __construct($record, $product_wrapper, $match, $group_name = NULL) {
+    $this->container = array(
+      'commerce_product' => $product_wrapper->value(),
+      'quantity' => $record['quantity'],
+      'commerce_unit_price' => $product_wrapper->commerce_price->value(),
+      'cl_billing_start' => $record['start'],
+      'cl_billing_end' => $record['end'],
+      'match' => $match,
+    );
+
+    if (isset($record['revision_id'])) {
+      // Not all usage records supply the revision ID of the license, as
+      // it is not always relevant.
+      $this->container['license_revision_id'] = $record['revision_id'];
+    }
+
+    if ($group_name) {
+      $this->container['usage_group'] = $group_name;
     }
 
     // Fill in the blanks.
-    foreach (static::SCHEMA as $k) {
+    foreach (static::$schema as $k) {
       if (!isset($this->container[$k])) {
         $this->container[$k] = NULL;
       }
@@ -43,7 +55,7 @@ class CommerceLicenseBillingCharge implements CommerceLicenseBillingChargeInterf
     }
     $match = TRUE;
     foreach ($this->container['match'] as $key) {
-      if (!in_array($key, static::SCHEMA)) {
+      if (!in_array($key, static::$schema)) {
         throw new DomainException("Trying to match data value not in the schema for this charge type.");
       }
 
@@ -95,7 +107,7 @@ class CommerceLicenseBillingCharge implements CommerceLicenseBillingChargeInterf
     if (is_null($offset)) {
       throw new DomainException("This charge type does not support unmapped data elements.");
     }
-    elseif (!in_array($offset, static::SCHEMA)) {
+    elseif (!in_array($offset, static::$schema)) {
       throw new DomainException("This charge type does not support the $offset data element.");
     }
     else {

--- a/plugins/usage_group/CommerceLicenseBillingCounterUsageGroup.class.php
+++ b/plugins/usage_group/CommerceLicenseBillingCounterUsageGroup.class.php
@@ -93,16 +93,13 @@ class CommerceLicenseBillingCounterUsageGroup extends CommerceLicenseBillingUsag
     if ($total > 0) {
       $product = commerce_product_load_by_sku($this->groupInfo['product']);
       $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
-      $def = array(
-        'usage_group' => $this->groupName,
+      $match = array('commerce_product', 'cl_billing_start');
+      $total_record = array(
         'quantity' => $total,
-        'commerce_product' => $product,
-        'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-        'cl_billing_start' => $billingCycle->start,
-        'cl_billing_end' => $billingCycle->end,
-        'match' => array('commerce_product', 'cl_billing_start'),
+        'start' => $billingCycle->start,
+        'end' => $billingCycle->end,
       );
-      $charges[] = $this->generateCharge($def);
+      $charges[] = $this->generateCharge($total_record, $product_wrapper, $match);
     }
 
     return $charges;

--- a/plugins/usage_group/CommerceLicenseBillingCounterUsageGroup.class.php
+++ b/plugins/usage_group/CommerceLicenseBillingCounterUsageGroup.class.php
@@ -58,7 +58,7 @@ class CommerceLicenseBillingCounterUsageGroup extends CommerceLicenseBillingUsag
    * collapsed into one record per usage group.
    */
   public function chargeableUsage(CommerceLicenseBillingCycle $billingCycle) {
-    $chargeable_usage = array();
+    $charges = array();
     $usage = $this->usageHistory($billingCycle);
     $free_quantities = $this->freeQuantities($billingCycle);
     $billing_cycle_duration = $billingCycle->end - $billingCycle->start;
@@ -91,15 +91,21 @@ class CommerceLicenseBillingCounterUsageGroup extends CommerceLicenseBillingUsag
     }
 
     if ($total > 0) {
-      $chargeable_usage[] = array(
+      $product = commerce_product_load_by_sku($this->groupInfo['product']);
+      $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+      $def = array(
         'usage_group' => $this->groupName,
         'quantity' => $total,
-        'start' => $billingCycle->start,
-        'end' => $billingCycle->end,
+        'commerce_product' => $product,
+        'commerce_unit_price' => $product_wrapper->commerce_price->value(),
+        'cl_billing_start' => $billingCycle->start,
+        'cl_billing_end' => $billingCycle->end,
+        'match' => array('commerce_product', 'cl_billing_start'),
       );
+      $charges[] = $this->generateCharge($def);
     }
 
-    return $chargeable_usage;
+    return $charges;
   }
 
   /**

--- a/plugins/usage_group/CommerceLicenseBillingGaugeUsageGroup.class.php
+++ b/plugins/usage_group/CommerceLicenseBillingGaugeUsageGroup.class.php
@@ -89,20 +89,9 @@ class CommerceLicenseBillingGaugeUsageGroup extends CommerceLicenseBillingUsageG
     $product = commerce_product_load_by_sku($this->groupInfo['product']);
     $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
     $charges = array();
+    $match = array('commerce_product', 'cl_billing_start');
     foreach ($usage as $usage_record) {
-      $def = array(
-        // Not all usage records supply the revision ID of the license, as
-        //   is it not always relevant.
-        'license_revision_id' => $usage_record['revision_id'],
-        'commerce_product' => $product,
-        'quantity' => $usage_record['quantity'],
-        'commerce_unit_price' => $product_wrapper->commerce_price->value(),
-        'cl_billing_start' => $usage_record['start'],
-        'cl_billing_end' => $usage_record['end'],
-        'match' => array('commerce_product', 'cl_billing_start'),
-        'usage_group' => $this->groupName,
-      );
-      $charges[] = $this->generateCharge($def);
+      $charges[] = $this->generateCharge($usage_record, $product_wrapper, $match);
     }
 
     return $charges;

--- a/plugins/usage_group/base.inc
+++ b/plugins/usage_group/base.inc
@@ -188,6 +188,13 @@ abstract class CommerceLicenseBillingUsageGroupBase implements CommerceLicenseBi
     return $plan_duration == $usage_duration;
   }
 
+  public function generateCharge($definition) {
+    $class = empty($this->groupInfo['charge_class']) ? 'CommerceLicenseBillingCharge' : $this->groupInfo['charge_class'];
+    $charge = new $class($definition);
+
+    return $charge;
+  }
+
   /**
    * Implements CommerceLicenseBillingUsageGroupInterface::onRevisionChange().
    */

--- a/plugins/usage_group/base.inc
+++ b/plugins/usage_group/base.inc
@@ -188,9 +188,11 @@ abstract class CommerceLicenseBillingUsageGroupBase implements CommerceLicenseBi
     return $plan_duration == $usage_duration;
   }
 
-  public function generateCharge($definition) {
-    $class = empty($this->groupInfo['charge_class']) ? 'CommerceLicenseBillingCharge' : $this->groupInfo['charge_class'];
-    $charge = new $class($definition);
+  public function generateCharge($usage_record, $product_wrapper, $match, $class = NULL) {
+    if (!$class) {
+      $class = empty($this->groupInfo['charge_class']) ? 'CommerceLicenseBillingCharge' : $this->groupInfo['charge_class'];
+    }
+    $charge = new $class($usage_record, $product_wrapper, $match, $this->groupName);
 
     return $charge;
   }


### PR DESCRIPTION
The point of this was to provide a way for a "charge" to be an actual object which can have methods and be extended, if necessary, by its usage group. It also systematizes the creation of charges a bit better (I think) and wraps them in API functions (either within the usage group or a new function for plans.)

I realized near the end that this probably isn't fully necessary to achieve my ACTUAL goal, which is multiple charges per usage record for upcoming custom usage groups...but it does provide more flexibility. The question is if I needed to go the whole-hog object-with-interface route or if I should have just let the usage group implement a default ::match() static method and then overridden it if required...

What I do still like is that it separates the concept of "this is a plan record" and "this is a usage record" from "this is a charge", or at least starts down that path. Philosophical thoughts are welcome.